### PR TITLE
feat: read csv file concurrently

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -39,6 +39,7 @@ func (a *App) injectDependencies() {
 
 func (a *App) setRoutes() {
 	a.Router.GET("/pokemons", a.pokemonHandler.FindPokemons)
+	a.Router.GET("v2/pokemons", a.pokemonHandler.FindPokemonsConcurrently)
 	a.Router.GET("/pokemons/:id", a.pokemonHandler.FindPokemonById)
 	a.Router.PUT("/load/pokemons", a.pokemonHandler.LoadPokemons)
 }

--- a/common/numbers.go
+++ b/common/numbers.go
@@ -1,0 +1,5 @@
+package common
+
+func Even(number int) bool {
+	return number%2 == 0
+}

--- a/controllers/pokemon_controller.go
+++ b/controllers/pokemon_controller.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"golangBootcamp/m/models"
 	"net/http"
+	"time"
 
 	"strconv"
 
@@ -13,6 +14,7 @@ import (
 type pokemonService interface {
 	FindAllPokemons() ([]models.Pokemon, error)
 	FindPokemonById(id int) (*models.Pokemon, error)
+	FindPokemonByType(idType string, items int, itemsPerWorker int) ([]models.Pokemon, error)
 	LoadPokemons() error
 }
 
@@ -24,6 +26,11 @@ func NewPokemonServiceHandler(pokemonService pokemonService) PokemonServiceHandl
 	return PokemonServiceHandler{pokemonService}
 }
 
+var AllowedIdTypes = map[string]bool{
+	"odd":  true,
+	"even": true,
+}
+
 func (pks PokemonServiceHandler) FindPokemons(c *gin.Context) {
 	pokemons, err := pks.pokemonService.FindAllPokemons()
 	if err != nil {
@@ -31,6 +38,35 @@ func (pks PokemonServiceHandler) FindPokemons(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"message": "Something went wrong!"})
 		return
 	}
+	c.JSON(http.StatusOK, gin.H{"data": pokemons})
+}
+
+func (pks PokemonServiceHandler) FindPokemonsConcurrently(c *gin.Context) {
+	idType := c.Query("type")
+	items, itemsErr := strconv.Atoi(c.Query("items"))
+	itemsPerWorkers, itemsPWErr := strconv.Atoi(c.Query("items_per_workers"))
+	if itemsErr != nil {
+		fmt.Println("Error ", itemsErr)
+		c.JSON(http.StatusBadRequest, gin.H{"message": "Invalid items param"})
+		return
+	}
+	if itemsPWErr != nil {
+		fmt.Println("Error ", itemsPWErr)
+		c.JSON(http.StatusBadRequest, gin.H{"message": "Invalid items per worker param"})
+		return
+	}
+	if _, ok := AllowedIdTypes[idType]; !ok {
+		c.JSON(http.StatusBadRequest, gin.H{"message": "Invalid type param"})
+		return
+	}
+	start := time.Now()
+	pokemons, err := pks.pokemonService.FindPokemonByType(idType, items, itemsPerWorkers)
+	if err != nil {
+		fmt.Println("Error ", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"message": "Something went wrong!"})
+		return
+	}
+	fmt.Printf("\n%2fs", time.Since(start).Seconds())
 	c.JSON(http.StatusOK, gin.H{"data": pokemons})
 }
 

--- a/controllers/pokemon_controller.go
+++ b/controllers/pokemon_controller.go
@@ -43,20 +43,20 @@ func (pks PokemonServiceHandler) FindPokemons(c *gin.Context) {
 
 func (pks PokemonServiceHandler) FindPokemonsConcurrently(c *gin.Context) {
 	idType := c.Query("type")
-	items, itemsErr := strconv.Atoi(c.Query("items"))
-	itemsPerWorkers, itemsPWErr := strconv.Atoi(c.Query("items_per_workers"))
-	if itemsErr != nil {
-		fmt.Println("Error ", itemsErr)
+	if _, ok := AllowedIdTypes[idType]; !ok {
+		c.JSON(http.StatusBadRequest, gin.H{"message": "Invalid type param"})
+		return
+	}
+	items, err := strconv.Atoi(c.Query("items"))
+	if err != nil {
+		fmt.Println("Error ", err)
 		c.JSON(http.StatusBadRequest, gin.H{"message": "Invalid items param"})
 		return
 	}
-	if itemsPWErr != nil {
-		fmt.Println("Error ", itemsPWErr)
+	itemsPerWorkers, err := strconv.Atoi(c.Query("items_per_workers"))
+	if err != nil {
+		fmt.Println("Error ", err)
 		c.JSON(http.StatusBadRequest, gin.H{"message": "Invalid items per worker param"})
-		return
-	}
-	if _, ok := AllowedIdTypes[idType]; !ok {
-		c.JSON(http.StatusBadRequest, gin.H{"message": "Invalid type param"})
 		return
 	}
 	start := time.Now()

--- a/controllers/pokemon_controller_test.go
+++ b/controllers/pokemon_controller_test.go
@@ -29,6 +29,10 @@ func (mpsh MockedPokemonServiceHandler) LoadPokemons() error {
 	return mpsh.expectedError
 }
 
+func (mpsh MockedPokemonServiceHandler) FindPokemonByType(idType string, items int, itemsPerWorker int) ([]models.Pokemon, error) {
+	return nil, nil
+}
+
 func TestFindPokemons(t *testing.T) {
 	subtests := []struct {
 		name           string

--- a/repositories/pokemon_repo.go
+++ b/repositories/pokemon_repo.go
@@ -1,9 +1,15 @@
 package repositories
 
 import (
+	"context"
+	"encoding/csv"
 	"fmt"
+	"golangBootcamp/m/common"
 	"golangBootcamp/m/models"
+	"io"
+	"os"
 	"strconv"
+	"sync"
 )
 
 type PokemonCSV interface {
@@ -47,4 +53,86 @@ func (pr PokemonRepo) WritePokemonCsvFile(pokemons []models.Pokemon) error {
 		return err
 	}
 	return nil
+}
+
+func (pr PokemonRepo) GetPokemonsFromCSVConcurrently(idType string, items int, itemsPerWorker int) ([]models.Pokemon, error) {
+	numberOfWorkers := items / itemsPerWorker
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	defer cancel()
+	row := make(chan []string)
+	pokemon := make(chan models.Pokemon)
+	readedItems := 0
+
+	csvfile, err := os.Open(pr.dataFilePath)
+	if err != nil {
+		return nil, err
+	}
+	defer csvfile.Close()
+
+	reader := csv.NewReader(csvfile)
+
+	go func() {
+		for {
+			record, err := reader.Read()
+			if err == io.EOF {
+				break
+			} else if err != nil {
+				return
+			}
+			row <- record
+		}
+		close(row)
+	}()
+
+	for i := 0; i < numberOfWorkers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			pokemonObtainer(ctx, pokemon, row, idType)
+		}()
+	}
+
+	go func() {
+		wg.Wait()
+		close(pokemon)
+	}()
+
+	pokemonList := []models.Pokemon{}
+	for res := range pokemon {
+		if readedItems == items {
+			break
+		}
+		pokemonList = append(pokemonList, res)
+		readedItems++
+	}
+
+	return pokemonList, nil
+}
+
+func pokemonObtainer(ctx context.Context, pokemon chan models.Pokemon, src chan []string, idType string) {
+	for {
+		select {
+		case row, ok := <-src:
+			if !ok {
+				return
+			}
+			intId, err := strconv.Atoi(row[0])
+			if err != nil {
+				return
+			}
+			switch idType {
+			case "even":
+				if common.Even(intId) {
+					pokemon <- models.Pokemon{Id: intId, Name: row[1]}
+				}
+			case "odd":
+				if !common.Even(intId) {
+					pokemon <- models.Pokemon{Id: intId, Name: row[1]}
+				}
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
 }

--- a/repositories/pokemon_repo.go
+++ b/repositories/pokemon_repo.go
@@ -61,7 +61,7 @@ func (pr PokemonRepo) GetPokemonsFromCSVConcurrently(idType string, items int, i
 	var wg sync.WaitGroup
 	defer cancel()
 	row := make(chan []string)
-	pokemon := make(chan models.Pokemon)
+	pokemon := make(chan models.Pokemon, numberOfWorkers)
 	readedItems := 0
 
 	csvfile, err := os.Open(pr.dataFilePath)

--- a/services/pokemon_service.go
+++ b/services/pokemon_service.go
@@ -8,6 +8,7 @@ import (
 type pokemonRepo interface {
 	GetPokemonsFromCSV() ([]models.Pokemon, error)
 	WritePokemonCsvFile(pokemons []models.Pokemon) error
+	GetPokemonsFromCSVConcurrently(idType string, items int, itemsPerWorker int) ([]models.Pokemon, error)
 }
 
 type pokemonClient interface {
@@ -42,6 +43,14 @@ func (pks PokemonService) FindPokemonById(id int) (*models.Pokemon, error) {
 		}
 	}
 	return nil, nil
+}
+
+func (pks PokemonService) FindPokemonByType(idType string, items int, itemsPerWorker int) ([]models.Pokemon, error) {
+	pokemons, err := pks.repo.GetPokemonsFromCSVConcurrently(idType, items, itemsPerWorker)
+	if err != nil {
+		return nil, err
+	}
+	return pokemons, nil
 }
 
 func (pks PokemonService) LoadPokemons() error {

--- a/services/pokemon_service_test.go
+++ b/services/pokemon_service_test.go
@@ -21,6 +21,10 @@ func (mpr MockedPokemonRepo) WritePokemonCsvFile(pokemons []models.Pokemon) erro
 	return nil
 }
 
+func (mpr MockedPokemonRepo) GetPokemonsFromCSVConcurrently(idType string, items int, itemsPerWorker int) ([]models.Pokemon, error) {
+	return nil, nil
+}
+
 type MockedPokemonClient struct {
 	expectedPokemons []models.Pokemon
 	expectedError    error


### PR DESCRIPTION
- Add a new endpoint
- The endpoint must read items from the CSV concurrently using a worker pool
- The endpoint must support the following query params:

```text
type: Only support "odd" or "even"
items: Is an Int and is the amount of valid items you need to display as a response
items_per_workers: Is an Int and is the amount of valid items the worker should append to the response
```

- Reject the values according to the query param ***type*** (you could use an ID column)
- Instruct the workers to shut down according to the query param ***items_per_workers*** collected
- The result should be displayed as a response
- The response should be displayed when:

  - The workers reached the limit
  - EOF
  - Valid items completed